### PR TITLE
fix(sec): upgrade net.sourceforge.htmlunit:htmlunit to 2.37.0

### DIFF
--- a/wgcloud-server/pom.xml
+++ b/wgcloud-server/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>net.sourceforge.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.34.0</version>
+            <version>2.37.0</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in net.sourceforge.htmlunit:htmlunit 2.34.0
- [CVE-2020-5529](https://www.oscs1024.com/hd/CVE-2020-5529)


### What did I do？
Upgrade net.sourceforge.htmlunit:htmlunit from 2.34.0 to 2.37.0 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How was this patch tested?
Run `mvn compile` failed locally, couldn't complete the build process.
Run `mvn clean test` failed locally, unit-test couldn't pass.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS